### PR TITLE
2. Customize additional default Splash from Android 12

### DIFF
--- a/BasicAppSample/app/src/main/AndroidManifest.xml
+++ b/BasicAppSample/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
             android:name=".SplashActivity"
             android:exported="true"
             android:noHistory="true"
-            android:theme="@style/Theme.BasicAppSample.NoActionBar">
+            android:theme="@style/Theme.BasicAppSample.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/BasicAppSample/app/src/main/res/drawable/ic_baseline_bedtime_24.xml
+++ b/BasicAppSample/app/src/main/res/drawable/ic_baseline_bedtime_24.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.85" android:height="24dp"
+    android:tint="#00FF8C" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12.34,2.02C6.59,1.82 2,6.42 2,12c0,5.52 4.48,10 10,10c3.71,0 6.93,-2.02 8.66,-5.02C13.15,16.73 8.57,8.55 12.34,2.02z"/>
+</vector>

--- a/BasicAppSample/app/src/main/res/values/themes.xml
+++ b/BasicAppSample/app/src/main/res/values/themes.xml
@@ -18,4 +18,17 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
+
+    <style name="Theme.BasicAppSample.Starting" parent="Theme.SplashScreen">
+        <!-- Set the splash screen background, animated icon, and animation duration. -->
+        <item name="windowSplashScreenBackground">@color/teal_700</item>
+
+        <!-- Use windowSplashScreenAnimatedIcon to add either a drawable or an animated drawable.
+        One of these is required.-->
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_baseline_bedtime_24</item>
+        <item name="windowSplashScreenAnimationDuration">200</item>
+
+        <!-- Set the theme of the Activity that directly follows your splash screen.-->
+        <item name="postSplashScreenTheme">@style/Theme.BasicAppSample</item>
+    </style>
 </resources>


### PR DESCRIPTION
Android 12から追加のデフォルトスプラッシュをカスタマイズする

https://developer.android.com/guide/topics/ui/splash-screen/migrate#migrate_your_splash_screen_implementation
まだ、既存の Splashアクティビティが表示されている。
<img src="https://user-images.githubusercontent.com/16476224/143676166-1d7ee9af-3763-4a06-8c0c-dcd48c633644.gif" width=320 />